### PR TITLE
specify region in cloudwatch client

### DIFF
--- a/src/aws-widgets/aws-cloud-watch-metric-graph.tsx
+++ b/src/aws-widgets/aws-cloud-watch-metric-graph.tsx
@@ -131,7 +131,8 @@ export class AwsCloudWatchMetricGraph extends BaseWidget {
       throw new Error('An AwsCredentialsProvider was expected, but was not given');
     }
 
-    this.timeRange = cleanTimeRange(this.timeRange, overrides);    
+    this.timeRange = cleanTimeRange(this.timeRange, overrides);
+
     const awsCredentialsProvider = getAwsCredentialsProvider(providers);
     const cwClient = new CloudWatch({
       credentials: await awsCredentialsProvider.getCredentials(AwsSdkVersionEnum.V3),


### PR DESCRIPTION
## Pull Request Type
 - [ ] Feature
 - [x] Bug Fix

## Summary of Bug Fix(es)
### Previous Behaviour
_Description of the bug and it's impact_
AwsCloudWatchMetricGraph was not setting the region on the CloudWatch client so the default region from the environment would be used.  

### New Behaviour
_Description of the bug fix and it's impact_
Now it sets the region using this.region.

## Other details
Correction: ops-api does not directly depend on this package so only the SaaS stacks need to be re-built.
~Once this is released we'll need to update ops-api with the latest version of this module and release a new public image.~
Then any SaaS stacks will need to be re-built (only Safeer and I have stacks so far).  These can be re-built by hitting the update API or re-deploying through the cli.